### PR TITLE
3. The vec3 Class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,5 +4,6 @@ target_sources(WeekendRaytracer
     PRIVATE
         vec3.h
         vec3.cpp
+        color.h
         main.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,5 +2,7 @@ add_executable(WeekendRaytracer)
 
 target_sources(WeekendRaytracer
     PRIVATE
+        vec3.h
+        vec3.cpp
         main.cpp
 )

--- a/src/color.h
+++ b/src/color.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "vec3.h"
+
+#include <iostream>
+
+using color = vec3;
+
+inline void write_color(std::ostream& out, const color& pixel_color) {
+    // Write the translated [0, 255] value of each color component
+    out << static_cast<int>(255.999 * pixel_color.x()) << ' '
+        << static_cast<int>(255.999 * pixel_color.y()) << ' '
+        << static_cast<int>(255.999 * pixel_color.z()) << '\n';
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,6 @@
+#include "vec3.h"
+#include "color.h"
+
 #include <iostream>
 
 int main() {
@@ -14,15 +17,10 @@ int main() {
     for (int j = image_height-1; j >= 0; --j) {
         std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
         for (int i = 0; i < image_width; ++i) {
-            auto r = static_cast<double>(i) / (image_width-1);
-            auto g = static_cast<double>(j) / (image_height-1);
-            auto b = 0.25;
-
-            int ir = static_cast<int>(255.999 * r);
-            int ig = static_cast<int>(255.999 * g);
-            int ib = static_cast<int>(255.999 * b);
-
-            std::cout << ir << ' ' << ig << ' ' << ib << '\n';
+            color pixel_color(static_cast<double>(i) / (image_width-1)
+                , static_cast<double>(j) / (image_height-1)
+                , 0.25);
+            write_color(std::cout, pixel_color);
         }
     }
     std::cerr << "\nDone.\n";

--- a/src/vec3.cpp
+++ b/src/vec3.cpp
@@ -1,0 +1,50 @@
+#include "vec3.h"
+
+#include <cmath>
+
+vec3::vec3() : e{ { 0.0, 0.0, 0.0 } } {};
+vec3::vec3(double e0, double e1, double e2) : e{ { e0, e1, e2 } } {};
+
+double vec3::x() const { return e[0]; }
+double vec3::y() const { return e[1]; }
+double vec3::z() const { return e[2]; }
+
+vec3 vec3::operator-() const { return vec3(-e[0], -e[1], -e[2]); }
+double vec3::operator[](int i) const { return e[i]; }
+double& vec3::operator[](int i) { return e[i]; }
+
+vec3& vec3::operator+=(const vec3& v) {
+    e[0] += v.e[0];
+    e[1] += v.e[1];
+    e[2] += v.e[2];
+    return *this;
+}
+
+vec3& vec3::operator*=(const vec3& v) {
+    e[0] *= e[0];
+    e[1] *= e[1];
+    e[2] *= e[2];
+    return *this;
+}
+
+vec3& vec3::operator*=(double t) {
+    e[0] *= t;
+    e[1] *= t;
+    e[2] *= t;
+    return *this;
+}
+
+vec3& vec3::operator/=(double t) {
+    e[0] /= t;
+    e[1] /= t;
+    e[2] /= t;
+    return *this;
+}
+
+double vec3::length() const {
+    return std::sqrt(length_squared());
+}
+
+double vec3::length_squared() const {
+    return e[0]*e[0] + e[1]*e[1] + e[2]*e[2];
+}

--- a/src/vec3.h
+++ b/src/vec3.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <array>
+#include <iostream>
+
+class vec3 {
+    public:
+        std::array<double, 3> e;
+
+    public:
+        vec3();
+        vec3(double e0, double e1, double e2);
+
+        double x() const;
+        double y() const;
+        double z() const;
+
+        vec3 operator-() const;
+        double operator[](int i) const;
+        double& operator[](int i);
+        
+        vec3& operator+=(const vec3& v);
+        vec3& operator*=(const vec3& v);
+        vec3& operator*=(double t);
+        vec3& operator/=(double t);
+
+        double length() const;
+        double length_squared() const;
+};
+
+// Type aliases
+using point3 = vec3;
+
+// Utility functions
+inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
+    return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
+}
+
+inline vec3 operator+(vec3 u, const vec3& v) {
+    u += v;
+    return u;
+}
+
+inline vec3 operator-(vec3 u, const vec3& v) {
+    u += -v;
+    return u;
+}
+
+inline vec3 operator*(vec3 u, const vec3& v) {
+    u *= v;
+    return u;
+}
+
+inline vec3 operator*(double t, vec3 v) {
+    v *= t;
+    return v;
+}
+
+inline vec3 operator*(vec3 v, double t) {
+    return t * v;
+}
+
+inline vec3 operator/(vec3 v, double t) {
+    v /= t;
+    return v;
+}
+
+inline double dot(vec3 u, const vec3& v) {
+    u *= v;
+    return u[0] + u[1] + u[2];
+}
+
+inline vec3 cross(vec3 u, const vec3& v) {
+    return vec3(u.e[1]*v.e[2] - u.e[2]*v.e[1]
+        , u.e[2]*v.e[0] - u.e[0]*v.e[2]
+        , u.e[0]*v.e[1] - u.e[1]*v.e[0]);
+}
+
+inline vec3 unit_vector(vec3 v) {
+    v /= v.length();
+    return v;
+}


### PR DESCRIPTION
Add

- `vec3` class
- `color` type (alias of `vec3`)
- `point3` type (alias of `vec3`)

Source: [_Ray Tracing in One Weekend_ - The vec3 Class](https://raytracing.github.io/books/RayTracingInOneWeekend.html#thevec3class)